### PR TITLE
Document setup.sh usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This package contains example scripts in 7 programming languages that perform ba
    ```bash
    export OPENAI_API_KEY="sk-..."
    ```
+4. Install all language dependencies with the provided script:
+   ```bash
+   sudo ./setup.sh
+   ```
+   This updates `apt` packages and installs Python, Node, Go, Rust, Java, and C++ requirements.
 
 ## 📂 Files
 


### PR DESCRIPTION
## Summary
- show how to run `setup.sh` for dependency installation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f631ced88328b5a50dd584515b90